### PR TITLE
split DataLoader

### DIFF
--- a/projects/adder/adder.py
+++ b/projects/adder/adder.py
@@ -8,7 +8,7 @@ import json
 
 import torch
 from torch.utils.data import Dataset
-from torch.utils.data.dataloader import DataLoader
+from tinygpt.tinyloader import DataLoader
 
 from tinygpt.model import GPT
 from tinygpt.trainer import Trainer

--- a/tinygpt/tinyloader.py
+++ b/tinygpt/tinyloader.py
@@ -1,0 +1,34 @@
+import torch
+
+
+class DataLoader(torch.utils.data.DataLoader):
+    """
+    Separate the trainer and projects from torch DataLoader by creating a proxy.
+
+    This DataLoader can be fed into tinygrad as well. We will eventually implement our own.
+    """
+
+    def __init__(self, dataset, batch_size=1, shuffle=False, sampler=None, 
+        batch_sampler=None, num_workers=0, collate_fn=None,
+        pin_memory=False, drop_last=False, timeout=0,
+        worker_init_fn=None, *, prefetch_factor=2,
+        persistent_workers=False):
+        """ Torch Dataloader signature:
+
+        DataLoader(dataset, batch_size=1, shuffle=False, sampler=None,
+            batch_sampler=None, num_workers=0, collate_fn=None,
+            pin_memory=False, drop_last=False, timeout=0,
+            worker_init_fn=None, *, prefetch_factor=2,
+            persistent_workers=False)
+
+        https://pytorch.org/docs/stable/data.html
+        """
+        super().__init__(
+            dataset=dataset,
+            sampler=sampler,
+            shuffle=shuffle,
+            pin_memory=pin_memory,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            drop_last=drop_last,
+        ) # Not all params are passeed. We'll see.

--- a/tinygpt/trainer.py
+++ b/tinygpt/trainer.py
@@ -7,7 +7,7 @@ import time
 from collections import defaultdict
 
 import torch
-from torch.utils.data.dataloader import DataLoader
+from tinygpt.tinyloader import DataLoader
 from tinygpt.utils import CfgNode as CN
 
 class Trainer:


### PR DESCRIPTION
separate torch dataloader from framework using a proxy (tinygrad doesn't have a data loader).

this changes only the framework and the adder.