### PR TITLE
Tinygradify

### DIFF
--- a/projects/adder/adder.py
+++ b/projects/adder/adder.py
@@ -8,7 +8,6 @@ import json
 
 import tinygrad
 import torch
-# from torch.utils.data import Dataset
 
 from tinygpt.tinyloader import DataLoader
 from tinygpt.model import GPT
@@ -152,12 +151,10 @@ if __name__ == '__main__':
         ndigit = config.data.ndigit
         results = []
         mistakes_printed_already = 0
-        tmp_device = 'cpu'
-        factors = torch.tensor([[10**i for i in range(ndigit+1)][::-1]]).to(tmp_device)
+        factors = torch.tensor([[10**i for i in range(ndigit+1)][::-1]])
         # factors = tinygrad.tensor.Tensor([[10**i for i in range(ndigit+1)][::-1]]).to(tmp_device)
         loader = DataLoader(dataset, batch_size=100, num_workers=0, drop_last=False)
         for b, (x, y) in enumerate(loader):
-            x = x.to(tmp_device)
             # isolate the first two digits of the input sequence alone
             d1d2 = x[:, :ndigit*2]
             # let the model sample the rest of the sequence

--- a/projects/adder/adder.py
+++ b/projects/adder/adder.py
@@ -6,10 +6,11 @@ import os
 import sys
 import json
 
-import torch
-from torch.utils.data import Dataset
-from tinygpt.tinyloader import DataLoader
+import tinygrad
+# import torch
+# from torch.utils.data import Dataset
 
+from tinygpt.tinyloader import DataLoader
 from tinygpt.model import GPT
 from tinygpt.trainer import Trainer
 from tinygpt.utils import set_seed, setup_logging, CfgNode as CN
@@ -147,7 +148,8 @@ if __name__ == '__main__':
         ndigit = config.data.ndigit
         results = []
         mistakes_printed_already = 0
-        factors = torch.tensor([[10**i for i in range(ndigit+1)][::-1]]).to(trainer.device)
+        # factors = torch.tensor([[10**i for i in range(ndigit+1)][::-1]]).to(trainer.device)
+        factors = tinygrad.tensor.Tensor([[10**i for i in range(ndigit+1)][::-1]]).to(trainer.device)
         loader = DataLoader(dataset, batch_size=100, num_workers=0, drop_last=False)
         for b, (x, y) in enumerate(loader):
             x = x.to(trainer.device)

--- a/projects/adder/adder.py
+++ b/projects/adder/adder.py
@@ -152,11 +152,12 @@ if __name__ == '__main__':
         ndigit = config.data.ndigit
         results = []
         mistakes_printed_already = 0
-        factors = torch.tensor([[10**i for i in range(ndigit+1)][::-1]]).to(trainer.device)
-        # factors = tinygrad.tensor.Tensor([[10**i for i in range(ndigit+1)][::-1]]).to(trainer.device)
+        tmp_device = 'cpu'
+        factors = torch.tensor([[10**i for i in range(ndigit+1)][::-1]]).to(tmp_device)
+        # factors = tinygrad.tensor.Tensor([[10**i for i in range(ndigit+1)][::-1]]).to(tmp_device)
         loader = DataLoader(dataset, batch_size=100, num_workers=0, drop_last=False)
         for b, (x, y) in enumerate(loader):
-            x = x.to(trainer.device)
+            x = x.to(tmp_device)
             # isolate the first two digits of the input sequence alone
             d1d2 = x[:, :ndigit*2]
             # let the model sample the rest of the sequence

--- a/tinygpt/model.py
+++ b/tinygpt/model.py
@@ -46,6 +46,7 @@ class CausalSelfAttention:
         # regularization
         self.attn_pdrop = config.attn_pdrop
         self.resid_pdrop = config.resid_pdrop
+        # causal mask to ensure that attention is only applied to the left in the input sequence
         self.bias = Tensor.ones(config.block_size, config.block_size).tril().view(1, 1, config.block_size, config.block_size)
         self.bias.requires_grad = False
         self.n_head = config.n_head
@@ -60,7 +61,6 @@ class CausalSelfAttention:
         q = q.view(B, T, self.n_head, C // self.n_head).transpose(1, 2) # (B, nh, T, hs)
         v = v.view(B, T, self.n_head, C // self.n_head).transpose(1, 2) # (B, nh, T, hs)
 
-        # causal mask to ensure that attention is only applied to the left in the input sequence
         # causal self-attention; Self-attend: (B, nh, T, hs) x (B, nh, hs, T) -> (B, nh, T, T)
         att = (q @ k.transpose(-2, -1)) * (1.0 / math.sqrt(k.size(-1)))
         att = att.masked_fill(self.bias[:,:,:T,:T] == 0, float('-inf'))

--- a/tinygpt/model.py
+++ b/tinygpt/model.py
@@ -14,13 +14,29 @@ import math
 # import torch.nn as nn
 from torch.nn.functional import cross_entropy
 import tinygrad
-from tinygrad import Tensor
+from tinygrad.tensor import Tensor
 import tinygrad.nn as nn
 
 from tinygpt import tinyutils
 from tinygpt.utils import CfgNode as CN
 
 # -----------------------------------------------------------------------------
+
+# def init_w(layer):
+#     if isinstance(module, nn.Linear):
+#         # torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
+#         module.weight = Tensor.normal(mean=0.0, std=0.02, shape=module.weight.shape)
+#         if module.bias is not None:
+#             # torch.nn.init.zeros_(module.bias)
+#             module.bias = Tensor.zeros(module.bias.shape)
+#     elif isinstance(module, nn.Embedding):
+#         # torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
+#         module.weight = Tensor.normal(mean=0.0, std=0.02, shape=module.weight.shape)
+#     elif isinstance(module, nn.LayerNorm):
+#         # torch.nn.init.zeros_(module.bias)
+#         module.bias = Tensor.zeros(module.bias.shape)
+#         # torch.nn.init.ones_(module.weight)
+#         module.weight = Tensor.ones(module.weight.shape)
 
 class NewGELU:#(nn.Module):
     """
@@ -160,76 +176,77 @@ class GPT:#(nn.Module):
         self.lm_head = nn.Linear(config.n_embd, config.vocab_size, bias=False)
 
         # init all weights, and apply a special scaled init to the residual projections, per GPT-2 paper
-        self.apply(self._init_weights)
-        for pn, p in self.named_parameters():
-            if pn.endswith('c_proj.weight'):
-                # torch.nn.init.normal_(p, mean=0.0, std=0.02/math.sqrt(2 * config.n_layer))
-                p = Tensor.normal(mean=0.0, std=0.02/math.sqrt(2 * config.n_layer), shape=p.shape)
+        # self.apply(self._init_weights)
+        # for pn, p in self.named_parameters():
+        #     if pn.endswith('c_proj.weight'):
+        #         # torch.nn.init.normal_(p, mean=0.0, std=0.02/math.sqrt(2 * config.n_layer))
+        #         p = Tensor.normal(mean=0.0, std=0.02/math.sqrt(2 * config.n_layer), shape=p.shape)
 
         # report number of parameters (note we don't count the decoder parameters in lm_head)
-        n_params = sum(p.numel() for p in self.transformer.parameters())
-        print("number of parameters: %.2fM" % (n_params/1e6,))
+        # TODO: bring this back
+        # n_params = sum(p.numel() for p in self.transformer.parameters())
+        # print("number of parameters: %.2fM" % (n_params/1e6,))
 
-    def _init_weights(self, module):
-        if isinstance(module, nn.Linear):
-            # torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
-            module.weight = Tensor.normal(mean=0.0, std=0.02, shape=module.weight.shape)
-            if module.bias is not None:
-                # torch.nn.init.zeros_(module.bias)
-                module.bias = Tensor.zeros(module.bias.shape)
-        elif isinstance(module, nn.Embedding):
-            # torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
-            module.weight = Tensor.normal(mean=0.0, std=0.02, shape=module.weight.shape)
-        elif isinstance(module, nn.LayerNorm):
-            # torch.nn.init.zeros_(module.bias)
-            module.bias = Tensor.zeros(module.bias.shape)
-            # torch.nn.init.ones_(module.weight)
-            module.weight = Tensor.ones(module.weight.shape)
+    # def _init_weights(self, module):
+    #     if isinstance(module, nn.Linear):
+    #         # torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
+    #         module.weight = Tensor.normal(mean=0.0, std=0.02, shape=module.weight.shape)
+    #         if module.bias is not None:
+    #             # torch.nn.init.zeros_(module.bias)
+    #             module.bias = Tensor.zeros(module.bias.shape)
+    #     elif isinstance(module, nn.Embedding):
+    #         # torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
+    #         module.weight = Tensor.normal(mean=0.0, std=0.02, shape=module.weight.shape)
+    #     elif isinstance(module, nn.LayerNorm):
+    #         # torch.nn.init.zeros_(module.bias)
+    #         module.bias = Tensor.zeros(module.bias.shape)
+    #         # torch.nn.init.ones_(module.weight)
+    #         module.weight = Tensor.ones(module.weight.shape)
 
-    @classmethod
-    def from_pretrained(cls, model_type):
-        """
-        Initialize a pretrained GPT model by copying over the weights
-        from a huggingface/transformers checkpoint.
-        """
-        assert model_type in {'gpt2', 'gpt2-medium', 'gpt2-large', 'gpt2-xl'}
-        from transformers import GPT2LMHeadModel
+    # @classmethod
+    # def from_pretrained(cls, model_type):
+    #     """
+    #     Initialize a pretrained GPT model by copying over the weights
+    #     from a huggingface/transformers checkpoint.
+    #     """
+    #     assert model_type in {'gpt2', 'gpt2-medium', 'gpt2-large', 'gpt2-xl'}
+    #     from transformers import GPT2LMHeadModel
 
-        # create a from-scratch initialized minGPT model
-        config = cls.get_default_config()
-        config.model_type = model_type
-        config.vocab_size = 50257 # openai's model vocabulary
-        config.block_size = 1024  # openai's model block_size
-        model = GPT(config)
-        sd = model.state_dict()
+    #     # create a from-scratch initialized minGPT model
+    #     config = cls.get_default_config()
+    #     config.model_type = model_type
+    #     config.vocab_size = 50257 # openai's model vocabulary
+    #     config.block_size = 1024  # openai's model block_size
+    #     model = GPT(config)
+    #     sd = model.state_dict()
 
-        # init a huggingface/transformers model
-        model_hf = GPT2LMHeadModel.from_pretrained(model_type)
-        sd_hf = model_hf.state_dict()
+    #     # init a huggingface/transformers model
+    #     model_hf = GPT2LMHeadModel.from_pretrained(model_type)
+    #     sd_hf = model_hf.state_dict()
 
-        # copy while ensuring all of the parameters are aligned and match in names and shapes
-        keys = [k for k in sd_hf if not k.endswith('attn.masked_bias')] # ignore these
-        transposed = ['attn.c_attn.weight', 'attn.c_proj.weight', 'mlp.c_fc.weight', 'mlp.c_proj.weight']
-        # basically the openai checkpoints use a "Conv1D" module, but we only want to use a vanilla nn.Linear.
-        # this means that we have to transpose these weights when we import them
-        assert len(keys) == len(sd)
-        for k in keys:
-            if any(k.endswith(w) for w in transposed):
-                # special treatment for the Conv1D weights we need to transpose
-                assert sd_hf[k].shape[::-1] == sd[k].shape
-                # with torch.no_grad():
-                Tensor.no_grad = True
-                sd[k].copy_(sd_hf[k].t())
-                Tensor.no_grad = False
-            else:
-                # vanilla copy over the other parameters
-                assert sd_hf[k].shape == sd[k].shape
-                # with torch.no_grad():
-                Tensor.no_grad = True
-                sd[k].copy_(sd_hf[k])
-                Tensor.no_grad = False
+    #     # copy while ensuring all of the parameters are aligned and match in names and shapes
+    #     keys = [k for k in sd_hf if not k.endswith('attn.masked_bias')] # ignore these
+    #     transposed = ['attn.c_attn.weight', 'attn.c_proj.weight', 'mlp.c_fc.weight', 'mlp.c_proj.weight']
+    #     # basically the openai checkpoints use a "Conv1D" module, but we only want to use a vanilla nn.Linear.
+    #     # this means that we have to transpose these weights when we import them
+    #     assert len(keys) == len(sd)
+    #     for k in keys:
+    #         if any(k.endswith(w) for w in transposed):
+    #             # special treatment for the Conv1D weights we need to transpose
+    #             assert sd_hf[k].shape[::-1] == sd[k].shape
+    #             # with torch.no_grad():
+    #             Tensor.no_grad = True
+    #             sd[k].copy_(sd_hf[k].t())
+    #             Tensor.no_grad = False
+    #         else:
+    #             # vanilla copy over the other parameters
+    #             assert sd_hf[k].shape == sd[k].shape
+    #             # with torch.no_grad():
+    #             Tensor.no_grad = True
+    #             sd[k].copy_(sd_hf[k])
+    #             Tensor.no_grad = False
 
-        return model
+    #     return model
 
     def configure_optimizers(self, train_config):
         """
@@ -244,36 +261,38 @@ class GPT:#(nn.Module):
         no_decay = set()
         whitelist_weight_modules = (tinygrad.nn.Linear, )
         blacklist_weight_modules = (tinygrad.nn.LayerNorm, tinygrad.nn.Embedding)
-        for mn, m in self.named_modules():
-            for pn, p in m.named_parameters():
-                fpn = '%s.%s' % (mn, pn) if mn else pn # full param name
-                # random note: because named_modules and named_parameters are recursive
-                # we will see the same tensors p many many times. but doing it this way
-                # allows us to know which parent module any tensor p belongs to...
-                if pn.endswith('bias'):
-                    # all biases will not be decayed
-                    no_decay.add(fpn)
-                elif pn.endswith('weight') and isinstance(m, whitelist_weight_modules):
-                    # weights of whitelist modules will be weight decayed
-                    decay.add(fpn)
-                elif pn.endswith('weight') and isinstance(m, blacklist_weight_modules):
-                    # weights of blacklist modules will NOT be weight decayed
-                    no_decay.add(fpn)
+        # TODO: what this?
+        # for mn, m in self.named_modules():
+        #     for pn, p in m.named_parameters():
+        #         fpn = '%s.%s' % (mn, pn) if mn else pn # full param name
+        #         # random note: because named_modules and named_parameters are recursive
+        #         # we will see the same tensors p many many times. but doing it this way
+        #         # allows us to know which parent module any tensor p belongs to...
+        #         if pn.endswith('bias'):
+        #             # all biases will not be decayed
+        #             no_decay.add(fpn)
+        #         elif pn.endswith('weight') and isinstance(m, whitelist_weight_modules):
+        #             # weights of whitelist modules will be weight decayed
+        #             decay.add(fpn)
+        #         elif pn.endswith('weight') and isinstance(m, blacklist_weight_modules):
+        #             # weights of blacklist modules will NOT be weight decayed
+        #             no_decay.add(fpn)
 
         # validate that we considered every parameter
-        param_dict = {pn: p for pn, p in self.named_parameters()}
-        inter_params = decay & no_decay
-        union_params = decay | no_decay
-        assert len(inter_params) == 0, "parameters %s made it into both decay/no_decay sets!" % (str(inter_params), )
-        assert len(param_dict.keys() - union_params) == 0, "parameters %s were not separated into either decay/no_decay set!" \
-                                                    % (str(param_dict.keys() - union_params), )
+        # param_dict = {pn: p for pn, p in self.named_parameters()}
+        # inter_params = decay & no_decay
+        # union_params = decay | no_decay
+        # assert len(inter_params) == 0, "parameters %s made it into both decay/no_decay sets!" % (str(inter_params), )
+        # assert len(param_dict.keys() - union_params) == 0, "parameters %s were not separated into either decay/no_decay set!" \
+        #                                             % (str(param_dict.keys() - union_params), )
 
         # create the pytorch optimizer object
-        optim_groups = [
-            {"params": [param_dict[pn] for pn in sorted(list(decay))], "weight_decay": train_config.weight_decay},
-            {"params": [param_dict[pn] for pn in sorted(list(no_decay))], "weight_decay": 0.0},
-        ]
-        optimizer = tinygrad.nn.optim.AdamW(optim_groups, lr=train_config.learning_rate, betas=train_config.betas)
+        # optim_groups = [
+        #     {"params": [param_dict[pn] for pn in sorted(list(decay))], "weight_decay": train_config.weight_decay},
+        #     {"params": [param_dict[pn] for pn in sorted(list(no_decay))], "weight_decay": 0.0},
+        # ]
+        params = tinygrad.nn.state.get_parameters(self)
+        optimizer = tinygrad.nn.optim.AdamW(params, lr=train_config.learning_rate, b1=train_config.betas[0], b2=train_config.betas[1])
         return optimizer
 
     def __call__(self, idx, targets=None):

--- a/tinygpt/model.py
+++ b/tinygpt/model.py
@@ -191,14 +191,14 @@ class GPT:
     #         if any(k.endswith(w) for w in transposed):
     #             # special treatment for the Conv1D weights we need to transpose
     #             assert sd_hf[k].shape[::-1] == sd[k].shape
-    #             # with torch.no_grad():
+    #             # with torc.no_grad():
     #             Tensor.no_grad = True
     #             sd[k].copy_(sd_hf[k].t())
     #             Tensor.no_grad = False
     #         else:
     #             # vanilla copy over the other parameters
     #             assert sd_hf[k].shape == sd[k].shape
-    #             # with torch.no_grad():
+    #             # with torc.no_grad():
     #             Tensor.no_grad = True
     #             sd[k].copy_(sd_hf[k])
     #             Tensor.no_grad = False

--- a/tinygpt/model.py
+++ b/tinygpt/model.py
@@ -81,14 +81,14 @@ class Block:
         self.ln_1 = nn.LayerNorm(config.n_embd)
         self.attn = CausalSelfAttention(config)
         self.ln_2 = nn.LayerNorm(config.n_embd)
-        self.resid_pdrop = config.resid_pdrop
         self.mlp = dict(
             c_fc    = nn.Linear(config.n_embd, 4 * config.n_embd),
             c_proj  = nn.Linear(4 * config.n_embd, config.n_embd),
             act     = NewGELU(),
+            dropout = config.resid_pdrop,
         )
         m = self.mlp
-        self.mlpf = lambda x: m['c_proj'](m['act'](m['c_fc'](x))).dropout(self.resid_pdrop) # MLP forward
+        self.mlpf = lambda x: m['c_proj'](m['act'](m['c_fc'](x))).dropout(m['dropout']) # MLP forward
 
     def __call__(self, x):
         x = x + self.attn(self.ln_1(x))

--- a/tinygpt/model.py
+++ b/tinygpt/model.py
@@ -19,21 +19,7 @@ from tinygpt.utils import CfgNode as CN
 
 # -----------------------------------------------------------------------------
 
-# def init_w(layer):
-#     if isinstance(module, nn.Linear):
-#         # torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
-#         module.weight = Tensor.normal(mean=0.0, std=0.02, shape=module.weight.shape)
-#         if module.bias is not None:
-#             # torch.nn.init.zeros_(module.bias)
-#             module.bias = Tensor.zeros(module.bias.shape)
-#     elif isinstance(module, nn.Embedding):
-#         # torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
-#         module.weight = Tensor.normal(mean=0.0, std=0.02, shape=module.weight.shape)
-#     elif isinstance(module, nn.LayerNorm):
-#         # torch.nn.init.zeros_(module.bias)
-#         module.bias = Tensor.zeros(module.bias.shape)
-#         # torch.nn.init.ones_(module.weight)
-#         module.weight = Tensor.ones(module.weight.shape)
+# NOTE: Tinygrad layer initialization doesn't support customizing the mean and std.
 
 class NewGELU:
     """
@@ -172,11 +158,7 @@ class GPT:
         self.lm_head = nn.Linear(config.n_embd, config.vocab_size, bias=False)
 
         # init all weights, and apply a special scaled init to the residual projections, per GPT-2 paper
-        # self.apply(self._init_weights)
-        # for pn, p in self.named_parameters():
-        #     if pn.endswith('c_proj.weight'):
-        #         # torch.nn.init.normal_(p, mean=0.0, std=0.02/math.sqrt(2 * config.n_layer))
-        #         p = Tensor.normal(mean=0.0, std=0.02/math.sqrt(2 * config.n_layer), shape=p.shape)
+        # NOTE: Tinygrad doesn't support custom initialization
 
         # report number of parameters (note we don't count the decoder parameters in lm_head)
         n_params = sum(p.numel() for p in tinygrad.nn.state.get_parameters(self.transformer))

--- a/tinygpt/model.py
+++ b/tinygpt/model.py
@@ -214,6 +214,7 @@ class GPT:
         """
 
         # NOTE: Tinygrad's AdamW doesn't support decay. hmmm...
+        # NOTE: There may be a way to do clever filtering here to exclude the no-grad `bias` tensors
         params = tinygrad.nn.state.get_parameters(self)
         optimizer = tinygrad.nn.optim.AdamW(params, lr=train_config.learning_rate, b1=train_config.betas[0], b2=train_config.betas[1])
         return optimizer

--- a/tinygpt/model.py
+++ b/tinygpt/model.py
@@ -10,7 +10,7 @@ https://github.com/huggingface/transformers/blob/main/src/transformers/models/gp
 
 import math
 
-import tinygrad
+from tinygrad import dtypes
 from tinygrad.tensor import Tensor
 import tinygrad.nn as nn
 
@@ -157,7 +157,7 @@ class GPT:
         # NOTE: Tinygrad doesn't support custom initialization
 
         # report number of parameters (note we don't count the decoder parameters in lm_head)
-        n_params = sum(p.numel() for p in tinygrad.nn.state.get_parameters(self.transformer))
+        n_params = sum(p.numel() for p in nn.state.get_parameters(self.transformer))
         print("number of parameters: %.2fM" % (n_params/1e6,))
 
     # @classmethod
@@ -215,14 +215,14 @@ class GPT:
 
         # NOTE: Tinygrad's AdamW doesn't support decay. hmmm...
         # NOTE: There may be a way to do clever filtering here to exclude the no-grad `bias` tensors
-        params = tinygrad.nn.state.get_parameters(self)
-        optimizer = tinygrad.nn.optim.AdamW(params, lr=train_config.learning_rate, b1=train_config.betas[0], b2=train_config.betas[1])
+        params = nn.state.get_parameters(self)
+        optimizer = nn.optim.AdamW(params, lr=train_config.learning_rate, b1=train_config.betas[0], b2=train_config.betas[1])
         return optimizer
 
     def __call__(self, idx, targets=None):
         b, t = idx.size()
         assert t <= self.block_size, f"Cannot forward sequence of length {t}, block size is only {self.block_size}"
-        pos = Tensor.arange(0, t, dtype=tinygrad.dtypes.long).unsqueeze(0) # shape (1, t)
+        pos = Tensor.arange(0, t, dtype=dtypes.long).unsqueeze(0) # shape (1, t)
 
         # forward the GPT model itself
         tok_emb = self.transformer['wte'](idx) # token embeddings of shape (b, t, n_embd)

--- a/tinygpt/model.py
+++ b/tinygpt/model.py
@@ -180,9 +180,8 @@ class GPT:
         #         p = Tensor.normal(mean=0.0, std=0.02/math.sqrt(2 * config.n_layer), shape=p.shape)
 
         # report number of parameters (note we don't count the decoder parameters in lm_head)
-        # TODO: bring this back
-        # n_params = sum(p.numel() for p in self.transformer.parameters())
-        # print("number of parameters: %.2fM" % (n_params/1e6,))
+        n_params = sum(p.numel() for p in tinygrad.nn.state.get_parameters(self.transformer))
+        print("number of parameters: %.2fM" % (n_params/1e6,))
 
     # @classmethod
     # def from_pretrained(cls, model_type):

--- a/tinygpt/model.py
+++ b/tinygpt/model.py
@@ -232,46 +232,12 @@ class GPT:
         This long function is unfortunately doing something very simple and is being very defensive:
         We are separating out all parameters of the model into two buckets: those that will experience
         weight decay for regularization and those that won't (biases, and layernorm/embedding weights).
-        We are then returning the PyTorch optimizer object.
+        We are then returning the optimizer object.
         """
 
-        # separate out all parameters to those that will and won't experience regularizing weight decay
-        decay = set()
-        no_decay = set()
-        whitelist_weight_modules = (tinygrad.nn.Linear, )
-        blacklist_weight_modules = (tinygrad.nn.LayerNorm, tinygrad.nn.Embedding)
-        # TODO: what this?
-        # for mn, m in self.named_modules():
-        #     for pn, p in m.named_parameters():
-        #         fpn = '%s.%s' % (mn, pn) if mn else pn # full param name
-        #         # random note: because named_modules and named_parameters are recursive
-        #         # we will see the same tensors p many many times. but doing it this way
-        #         # allows us to know which parent module any tensor p belongs to...
-        #         if pn.endswith('bias'):
-        #             # all biases will not be decayed
-        #             no_decay.add(fpn)
-        #         elif pn.endswith('weight') and isinstance(m, whitelist_weight_modules):
-        #             # weights of whitelist modules will be weight decayed
-        #             decay.add(fpn)
-        #         elif pn.endswith('weight') and isinstance(m, blacklist_weight_modules):
-        #             # weights of blacklist modules will NOT be weight decayed
-        #             no_decay.add(fpn)
-
-        # validate that we considered every parameter
-        # param_dict = {pn: p for pn, p in self.named_parameters()}
-        # inter_params = decay & no_decay
-        # union_params = decay | no_decay
-        # assert len(inter_params) == 0, "parameters %s made it into both decay/no_decay sets!" % (str(inter_params), )
-        # assert len(param_dict.keys() - union_params) == 0, "parameters %s were not separated into either decay/no_decay set!" \
-        #                                             % (str(param_dict.keys() - union_params), )
-
-        # create the pytorch optimizer object
-        # optim_groups = [
-        #     {"params": [param_dict[pn] for pn in sorted(list(decay))], "weight_decay": train_config.weight_decay},
-        #     {"params": [param_dict[pn] for pn in sorted(list(no_decay))], "weight_decay": 0.0},
-        # ]
+        # NOTE: Tinygrad's AdamW doesn't support decay. hmmm...
         params = tinygrad.nn.state.get_parameters(self)
-        optimizer = tinygrad.nn.optim.Adam(params, lr=train_config.learning_rate, b1=train_config.betas[0], b2=train_config.betas[1])
+        optimizer = tinygrad.nn.optim.AdamW(params, lr=train_config.learning_rate, b1=train_config.betas[0], b2=train_config.betas[1])
         return optimizer
 
     def __call__(self, idx, targets=None):

--- a/tinygpt/tinyloader.py
+++ b/tinygpt/tinyloader.py
@@ -33,16 +33,16 @@ class DataLoader(torch.utils.data.DataLoader):
             drop_last=drop_last,
         ) # Not all params are passeed. We'll see.
 
-class RandomSampler(torch.utils.data.RandomSampler):
-    def __init__(self, data_source, replacement=False, num_samples=None):
-        """ Torch RandomSampler signature:
+    class RandomSampler(torch.utils.data.RandomSampler):
+        def __init__(self, data_source, replacement=False, num_samples=None):
+            """ Torch RandomSampler signature:
 
-        RandomSampler(data_source, replacement=False, num_samples=None)
+            RandomSampler(data_source, replacement=False, num_samples=None)
 
-        https://pytorch.org/docs/stable/data.html
-        """
-        super().__init__(
-            data_source=data_source,
-            replacement=replacement,
-            num_samples=num_samples,
-        )
+            https://pytorch.org/docs/stable/data.html
+            """
+            super().__init__(
+                data_source=data_source,
+                replacement=replacement,
+                num_samples=num_samples,
+            )

--- a/tinygpt/tinyloader.py
+++ b/tinygpt/tinyloader.py
@@ -32,3 +32,17 @@ class DataLoader(torch.utils.data.DataLoader):
             num_workers=num_workers,
             drop_last=drop_last,
         ) # Not all params are passeed. We'll see.
+
+class RandomSampler(torch.utils.data.RandomSampler):
+    def __init__(self, data_source, replacement=False, num_samples=None):
+        """ Torch RandomSampler signature:
+
+        RandomSampler(data_source, replacement=False, num_samples=None)
+
+        https://pytorch.org/docs/stable/data.html
+        """
+        super().__init__(
+            data_source=data_source,
+            replacement=replacement,
+            num_samples=num_samples,
+        )

--- a/tinygpt/tinyutils.py
+++ b/tinygpt/tinyutils.py
@@ -1,22 +1,22 @@
-import torch
 import numpy as np
 from tinygrad import Tensor
 
 def clip_grad_norm_(parameters, max_norm, norm_type=2.0, error_if_nonfinite=False, foreach=None):
+    import torch
     return torch.nn.utils.clip_grad_norm_(parameters, max_norm, norm_type, error_if_nonfinite, foreach)
 
 def topk(input_, k, dim=-1, largest=True, sorted=False):
-  k = min(k, input_.shape[dim]-1)
-  input_ = input_.numpy()
-  if largest: input_ *= -1
-  ind = np.argpartition(input_, k, axis=dim)
-  if largest: input_ *= -1
-  ind = np.take(ind, np.arange(k), axis=dim) # k non-sorted indices
-  input_ = np.take_along_axis(input_, ind, axis=dim) # k non-sorted values
-  if not sorted: return Tensor(input_), ind
-  if largest: input_ *= -1
-  ind_part = np.argsort(input_, axis=dim)
-  ind = np.take_along_axis(ind, ind_part, axis=dim)
-  if largest: input_ *= -1
-  val = np.take_along_axis(input_, ind_part, axis=dim)
-  return Tensor(val), ind
+    k = min(k, input_.shape[dim]-1)
+    input_ = input_.numpy()
+    if largest: input_ *= -1
+    ind = np.argpartition(input_, k, axis=dim)
+    if largest: input_ *= -1
+    ind = np.take(ind, np.arange(k), axis=dim) # k non-sorted indices
+    input_ = np.take_along_axis(input_, ind, axis=dim) # k non-sorted values
+    if not sorted: return Tensor(input_), ind
+    if largest: input_ *= -1
+    ind_part = np.argsort(input_, axis=dim)
+    ind = np.take_along_axis(ind, ind_part, axis=dim)
+    if largest: input_ *= -1
+    val = np.take_along_axis(input_, ind_part, axis=dim)
+    return Tensor(val), ind

--- a/tinygpt/tinyutils.py
+++ b/tinygpt/tinyutils.py
@@ -1,0 +1,22 @@
+import torch
+import numpy as np
+from tinygrad import Tensor
+
+def clip_grad_norm_(parameters, max_norm, norm_type=2.0, error_if_nonfinite=False, foreach=None):
+    return torch.nn.utils.clip_grad_norm_(parameters, max_norm, norm_type, error_if_nonfinite, foreach)
+
+def topk(input_, k, dim=-1, largest=True, sorted=False):
+  k = min(k, input_.shape[dim]-1)
+  input_ = input_.numpy()
+  if largest: input_ *= -1
+  ind = np.argpartition(input_, k, axis=dim)
+  if largest: input_ *= -1
+  ind = np.take(ind, np.arange(k), axis=dim) # k non-sorted indices
+  input_ = np.take_along_axis(input_, ind, axis=dim) # k non-sorted values
+  if not sorted: return Tensor(input_), ind
+  if largest: input_ *= -1
+  ind_part = np.argsort(input_, axis=dim)
+  ind = np.take_along_axis(ind, ind_part, axis=dim)
+  if largest: input_ *= -1
+  val = np.take_along_axis(input_, ind_part, axis=dim)
+  return Tensor(val), ind

--- a/tinygpt/trainer.py
+++ b/tinygpt/trainer.py
@@ -90,8 +90,7 @@ class Trainer:
             # model.zero_grad(set_to_none=True)
             self.optimizer.zero_grad()
             self.loss.backward()
-            # params = tinygrad.nn.state.get_parameters(model)
-            # tinyutils.clip_grad_norm_(params, config.grad_norm_clip)
+            # NOTE: tinygrad does not have clip_grad_norm_
             self.optimizer.step()
 
             self.trigger_callbacks('on_batch_end')

--- a/tinygpt/trainer.py
+++ b/tinygpt/trainer.py
@@ -6,7 +6,8 @@ so nothing in this file really has anything to do with GPT specifically.
 import time
 from collections import defaultdict
 
-import tinygrad
+from tinygrad.tensor import Tensor
+
 from tinygpt.tinyloader import DataLoader
 from tinygpt import tinyutils
 from tinygpt.utils import CfgNode as CN
@@ -65,7 +66,7 @@ class Trainer:
             num_workers=config.num_workers,
         )
 
-        t = tinygrad.tensor.Tensor.train()
+        t = Tensor.train()
         t.__enter__()
         self.iter_num = 0
         self.iter_time = time.time()
@@ -79,8 +80,8 @@ class Trainer:
                 data_iter = iter(train_loader)
                 batch = next(data_iter)
             x, y = batch
-            x = tinygrad.tensor.Tensor(x.numpy())
-            y = tinygrad.tensor.Tensor(y.numpy())
+            x = Tensor(x.numpy())
+            y = Tensor(y.numpy())
 
             # forward the model
             logits, self.loss = model(x, y)

--- a/tinygpt/trainer.py
+++ b/tinygpt/trainer.py
@@ -101,4 +101,4 @@ class Trainer:
             # termination conditions
             if config.max_iters is not None and self.iter_num >= config.max_iters:
                 break
-        t.__exit__()
+        t.__exit__(0, 0, 0)

--- a/tinygpt/trainer.py
+++ b/tinygpt/trainer.py
@@ -65,7 +65,6 @@ class Trainer:
             num_workers=config.num_workers,
         )
 
-        # model.train()
         t = tinygrad.tensor.Tensor.train()
         t.__enter__()
         self.iter_num = 0
@@ -87,7 +86,6 @@ class Trainer:
             logits, self.loss = model(x, y)
 
             # backprop and update the parameters
-            # model.zero_grad(set_to_none=True)
             self.optimizer.zero_grad()
             self.loss.backward()
             # NOTE: tinygrad does not have clip_grad_norm_

--- a/tinygpt/trainer.py
+++ b/tinygpt/trainer.py
@@ -92,16 +92,34 @@ class Trainer:
                     data_iter = iter(train_loader)
                     batch = next(data_iter)
                 # batch = [t.to(self.device) for t in batch]
+                # print(batch)
+                # print(type(batch))
+                # print(batch.shape)
                 x, y = batch
+                # print(x)
+                # print(type(x))
+                # print(x.shape)
+                x = tinygrad.tensor.Tensor(x.numpy())
+                y = tinygrad.tensor.Tensor(y.numpy())
 
+                btime = time.time()
                 # forward the model
                 logits, self.loss = model(x, y)
+                print(f'debug 1, time: {time.time() - btime}')
+                btime = time.time()
+                # print(logits.numpy())
 
                 # backprop and update the parameters
-                model.zero_grad(set_to_none=True)
+                # model.zero_grad(set_to_none=True)
+                self.optimizer.zero_grad()
                 self.loss.backward()
-                tinyutils.clip_grad_norm_(model.parameters(), config.grad_norm_clip)
+                print(f'debug 2, time: {time.time() - btime}')
+                btime = time.time()
+                # params = tinygrad.nn.state.get_parameters(model)
+                # tinyutils.clip_grad_norm_(params, config.grad_norm_clip)
                 self.optimizer.step()
+                print(f'debug 3, time: {time.time() - btime}')
+                btime = time.time()
 
                 self.trigger_callbacks('on_batch_end')
                 self.iter_num += 1
@@ -110,5 +128,6 @@ class Trainer:
                 self.iter_time = tnow
 
                 # termination conditions
-                if config.max_iters is not None and self.iter_num >= config.max_iters:
+                # if config.max_iters is not None and self.iter_num >= config.max_iters:
+                if self.iter_num >= 10:
                     break

--- a/tinygpt/trainer.py
+++ b/tinygpt/trainer.py
@@ -6,8 +6,10 @@ so nothing in this file really has anything to do with GPT specifically.
 import time
 from collections import defaultdict
 
-import torch
-from tinygpt.tinyloader import DataLoader
+# import torch
+# import tinygrad
+from tinygpt import tinyloader
+from tinygpt import tinyutils
 from tinygpt.utils import CfgNode as CN
 
 class Trainer:
@@ -37,7 +39,9 @@ class Trainer:
 
         # determine the device we'll train on
         if config.device == 'auto':
-            self.device = 'cuda' if torch.cuda.is_available() else 'cpu'
+            # self.device = 'cuda' if torc.cuda.is_available() else 'cpu'
+            # we will deal with cuda later
+            config.device = 'cpu'
         else:
             self.device = config.device
         self.model = self.model.to(self.device)
@@ -65,9 +69,9 @@ class Trainer:
         self.optimizer = model.configure_optimizers(config)
 
         # setup the dataloader
-        train_loader = DataLoader(
+        train_loader = tinyloader.DataLoader(
             self.train_dataset,
-            sampler=torch.utils.data.RandomSampler(self.train_dataset, replacement=True, num_samples=int(1e10)),
+            sampler=tinyloader.RandomSampler(self.train_dataset, replacement=True, num_samples=int(1e10)),
             shuffle=False,
             pin_memory=True,
             batch_size=config.batch_size,
@@ -95,7 +99,7 @@ class Trainer:
             # backprop and update the parameters
             model.zero_grad(set_to_none=True)
             self.loss.backward()
-            torch.nn.utils.clip_grad_norm_(model.parameters(), config.grad_norm_clip)
+            tinyutils.clip_grad_norm_(model.parameters(), config.grad_norm_clip)
             self.optimizer.step()
 
             self.trigger_callbacks('on_batch_end')

--- a/tinygpt/utils.py
+++ b/tinygpt/utils.py
@@ -6,7 +6,6 @@ import random
 from ast import literal_eval
 
 import numpy as np
-# import torch
 import tinygrad
 
 # -----------------------------------------------------------------------------
@@ -15,7 +14,6 @@ def set_seed(seed):
     random.seed(seed)
     np.random.seed(seed)
     tinygrad.Tensor.manual_seed(seed)
-    # tinygrad.cuda.manual_seed_all(seed)
 
 def setup_logging(config):
     """ monotonous bookkeeping """

--- a/tinygpt/utils.py
+++ b/tinygpt/utils.py
@@ -6,15 +6,16 @@ import random
 from ast import literal_eval
 
 import numpy as np
-import torch
+# import torch
+import tinygrad
 
 # -----------------------------------------------------------------------------
 
 def set_seed(seed):
     random.seed(seed)
     np.random.seed(seed)
-    torch.manual_seed(seed)
-    torch.cuda.manual_seed_all(seed)
+    tinygrad.Tensor.manual_seed(seed)
+    # tinygrad.cuda.manual_seed_all(seed)
 
 def setup_logging(config):
     """ monotonous bookkeeping """


### PR DESCRIPTION
First successful version of running minGPT on Tinygrad, with the following notes:

- clip_grad_norm still uses torch (as it's not implemented in tinygrad), even though it's entirely skipped
- a few more missing functions in tinygrad that are skipped
  - no way to customize initialization
  - no way to decay AdamW
- the `adder.py` is runnable and learns as fast as minGPT (step-wise), but each iter is significantly slower than torch. profiling seems to suggest some really slow work happening on CPU
- DataLoader and DataSet is still only a wrapper on torch. This likely will be the next thing to be rewritten in the next PR.